### PR TITLE
Explicitly requires request.

### DIFF
--- a/src/evergreen.el
+++ b/src/evergreen.el
@@ -2,6 +2,7 @@
 
 (provide 'evergreen)
 
+(require 'request)
 (require 'ansi-color)
 
 (defvar mdb-evg-mode-map nil "Keymap for evg-status page")


### PR DESCRIPTION
Avoids getting symbol not found when trying to use `request`